### PR TITLE
Configure identity-logging gem (LG-11815)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
+    google-protobuf (3.25.1-arm64-darwin)
     google-protobuf (3.25.1-x86_64-darwin)
     google-protobuf (3.25.1-x86_64-linux)
     i18n (1.14.1)
@@ -211,6 +212,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
@@ -380,6 +383,7 @@ GEM
     zonebie (0.6.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 require_relative '../lib/good_job_connection_pool_size'
 require_relative '../lib/identity_config'
 require_relative '../lib/version_headers'
+require 'identity/logging/railtie'
 
 APP_NAME = 'Identity Reporting Rails'.freeze
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,18 +41,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT).
-    tap  { |logger| logger.formatter = ::Logger::Formatter.new }.
-    then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
+  config.log_level = :info
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
## 🎫 Ticket

[LG-11815](https://cm-jira.usa.gov/browse/LG-11815)

## 🛠 Summary of changes

Configures the repo to use the already-installed `identity-logging` gem per [README instructions](https://github.com/18f/identity-logging?tab=readme-ov-file#usage)

## 📜 Testing Plan

Loaded the app and checked `development.log`:

```
{"method":"GET","path":"/","format":"html","controller":"Rails::WelcomeController","action":"index","status":200,"allocations":150,"duration":0.35,"view":0.22,"db":0.0,"view_runtime":0.2210000529885292,"db_runtime":0.0,"timestamp":"2023-12-18T20:09:33Z","uuid":"5fb7002a-3901-4460-8f7f-c8764105f2b0","pid":8109,"user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36","ip":"::1","host":"localhost","trace_id":null}
```
